### PR TITLE
Updated to include CSV command escaping

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,5 +1,5 @@
 === Plugin Name ===
-Contributors: webdevmattcrom
+Contributors: webdevmattcrom, theritesites
 Tags: user, users, csv, batch, export, exporter, admin
 Requires at least: 4.2
 Tested up to: 4.8


### PR DESCRIPTION
Escapes cells that start with + - = or @ with a single quote at the beginning of the cell.
Is annotated with further notes regarding conversions of languages as to prevent unicode or other types of encoded symbols that might be converted by the spreadsheet software, and adds a filter to support other encoded character packs.